### PR TITLE
Implement product search and header redesign

### DIFF
--- a/client/storewebapp/src/App.css
+++ b/client/storewebapp/src/App.css
@@ -4,16 +4,32 @@
 }
 
 .header {
+  display: flex;
+  align-items: center;
   background-color: #333;
   color: #fff;
-  padding: 20px 0;
-  text-align: center;
+  padding: 20px;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
 .header h1 {
   margin: 0;
   font-size: 2.5rem;
+}
+
+.search-container {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.search-container input {
+  width: 50%;
+  min-width: 200px;
+  padding: 8px;
+  font-size: 1rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
 }
 
 .container {

--- a/client/storewebapp/src/App.css
+++ b/client/storewebapp/src/App.css
@@ -131,3 +131,16 @@
   margin-top: 20px;
   font-size: 0.9rem;
 }
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+  gap: 10px;
+}
+
+.pagination button {
+  padding: 6px 12px;
+  cursor: pointer;
+}

--- a/client/storewebapp/src/App.js
+++ b/client/storewebapp/src/App.js
@@ -1,14 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './App.css';
 import ProductList from './components/ProductList';
 
 const App = () => {
+  const [search, setSearch] = useState('');
+
   return (
     <div className="App">
       <header className="header">
         <h1>Sklep Wszystko i Nic</h1>
+        <div className="search-container">
+          <input
+            type="text"
+            placeholder="Szukaj produktu..."
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+        </div>
       </header>
-      <ProductList />
+      <ProductList search={search} />
       <footer className="footer">
         <p>&copy; 2025 Sklep Wszystko i Nic. All rights reserved.</p>
       </footer>

--- a/client/storewebapp/src/App.test.js
+++ b/client/storewebapp/src/App.test.js
@@ -6,3 +6,10 @@ test('renders store header', () => {
   const headerElement = screen.getByRole('heading', { name: /Sklep Wszystko i Nic/i });
   expect(headerElement).toBeInTheDocument();
 });
+
+test('renders search input', () => {
+  render(<App />);
+  const input = screen.getByPlaceholderText(/Szukaj produktu/i);
+  expect(input).toBeInTheDocument();
+});
+

--- a/client/storewebapp/src/App.test.js
+++ b/client/storewebapp/src/App.test.js
@@ -13,3 +13,9 @@ test('renders search input', () => {
   expect(input).toBeInTheDocument();
 });
 
+test('renders pagination controls', () => {
+  render(<App />);
+  const nextButton = screen.getByRole('button', { name: /Next/i });
+  expect(nextButton).toBeInTheDocument();
+});
+

--- a/client/storewebapp/src/components/ProductList.js
+++ b/client/storewebapp/src/components/ProductList.js
@@ -5,16 +5,27 @@ const API_URL = 'http://localhost:5042/';
 
 const ProductList = ({ search }) => {
   const [products, setProducts] = useState([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
 
   useEffect(() => {
-    loadProducts(search);
+    setPage(1);
   }, [search]);
 
-  const loadProducts = term => {
-    const query = term ? `?search=${encodeURIComponent(term)}` : '';
-    fetch(`${API_URL}api/storewebapp/GetProducts${query}`)
+  useEffect(() => {
+    loadProducts(search, page);
+  }, [search, page]);
+
+  const loadProducts = (term, pageNum) => {
+    const params = new URLSearchParams();
+    if (term) params.append('search', term);
+    params.append('page', pageNum);
+    fetch(`${API_URL}api/storewebapp/GetProducts?${params.toString()}`)
       .then(res => res.json())
-      .then(data => setProducts(data))
+      .then(data => {
+        setProducts(data.items);
+        setTotalPages(data.totalPages);
+      })
       .catch(() => {});
   };
 
@@ -23,6 +34,9 @@ const ProductList = ({ search }) => {
       .then(() => setProducts(prev => prev.filter(p => p.id !== id)))
       .catch(() => {});
   };
+
+  const handlePrev = () => setPage(p => Math.max(1, p - 1));
+  const handleNext = () => setPage(p => Math.min(totalPages, p + 1));
 
   return (
     <div className="container">
@@ -35,6 +49,11 @@ const ProductList = ({ search }) => {
             onDelete={handleDelete}
           />
         ))}
+      </div>
+      <div className="pagination">
+        <button onClick={handlePrev} disabled={page === 1}>Prev</button>
+        <span>{page} / {totalPages}</span>
+        <button onClick={handleNext} disabled={page === totalPages}>Next</button>
       </div>
     </div>
   );

--- a/client/storewebapp/src/components/ProductList.js
+++ b/client/storewebapp/src/components/ProductList.js
@@ -51,9 +51,9 @@ const ProductList = ({ search }) => {
         ))}
       </div>
       <div className="pagination">
-        <button onClick={handlePrev} disabled={page === 1}>Prev</button>
+        <button onClick={handlePrev} disabled={page === 1}>&lt;</button>
         <span>{page} / {totalPages}</span>
-        <button onClick={handleNext} disabled={page === totalPages}>Next</button>
+        <button onClick={handleNext} disabled={page === totalPages}>&gt;</button>
       </div>
     </div>
   );

--- a/client/storewebapp/src/components/ProductList.js
+++ b/client/storewebapp/src/components/ProductList.js
@@ -3,15 +3,16 @@ import ProductCard from './ProductCard';
 
 const API_URL = 'http://localhost:5042/';
 
-const ProductList = () => {
+const ProductList = ({ search }) => {
   const [products, setProducts] = useState([]);
 
   useEffect(() => {
-    loadProducts();
-  }, []);
+    loadProducts(search);
+  }, [search]);
 
-  const loadProducts = () => {
-    fetch(`${API_URL}api/storewebapp/GetProducts`)
+  const loadProducts = term => {
+    const query = term ? `?search=${encodeURIComponent(term)}` : '';
+    fetch(`${API_URL}api/storewebapp/GetProducts${query}`)
       .then(res => res.json())
       .then(data => setProducts(data))
       .catch(() => {});

--- a/server/Controllers/StoreWebAppController.cs
+++ b/server/Controllers/StoreWebAppController.cs
@@ -19,10 +19,19 @@ namespace StoreWebApp.Controllers
 
         [HttpGet]
         [Route("GetProducts")]
-        public ActionResult<List<Product>> GetProducts()
+        public ActionResult<List<Product>> GetProducts([FromQuery] string? search)
         {
-            List<Product> products = _context.Products
-                .Where(p => !p.IsDeleted)
+            var query = _context.Products
+                .Where(p => !p.IsDeleted);
+
+            if (!string.IsNullOrWhiteSpace(search))
+            {
+                search = search.ToLower();
+                query = query.Where(p =>
+                    EF.Functions.Like(p.Title.ToLower(), $"%{search}%"));
+            }
+
+            List<Product> products = query
                 .Include(p => p.Categories)
                 .Include(p => p.Comments)
                 .AsNoTracking().ToList();

--- a/server/Controllers/StoreWebAppController.cs
+++ b/server/Controllers/StoreWebAppController.cs
@@ -23,7 +23,7 @@ namespace StoreWebApp.Controllers
         public ActionResult<PagedResult<Product>> GetProducts(
             [FromQuery] string? search,
             [FromQuery] int page = 1,
-            [FromQuery] int pageSize = 5)
+            [FromQuery] int pageSize = 4)
         {
             var query = _context.Products
                 .Where(p => !p.IsDeleted);

--- a/server/models/PagedResult.cs
+++ b/server/models/PagedResult.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace StoreWebApp.Models
+{
+    public class PagedResult<T>
+    {
+        public List<T> Items { get; set; } = new List<T>();
+        public int TotalPages { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add query support to `GetProducts` API endpoint
- create header search box and move title left
- filter products on search input
- adjust styles for new layout
- test for search field

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bfb74db0832694774495a1cc3889