### PR TITLE
Add product editing for admins

### DIFF
--- a/client/storewebapp/src/App.css
+++ b/client/storewebapp/src/App.css
@@ -233,7 +233,8 @@
   color: #fff;
   cursor: pointer;
   border-radius: 4px;
-  margin-left: 10px;
+  margin-left: 20px;
+  margin-top: 20px;
   transition: background-color 0.3s ease;
 }
 

--- a/client/storewebapp/src/App.css
+++ b/client/storewebapp/src/App.css
@@ -225,6 +225,22 @@
   background-color: #c0392b;
 }
 
+.edit-button {
+  background-color: #3498db;
+  border: none;
+  padding: 10px 20px;
+  font-size: 1rem;
+  color: #fff;
+  cursor: pointer;
+  border-radius: 4px;
+  margin-left: 10px;
+  transition: background-color 0.3s ease;
+}
+
+.edit-button:hover {
+  background-color: #2980b9;
+}
+
 .footer {
   background-color: #333;
   color: #ccc;

--- a/client/storewebapp/src/components/EditProductForm.js
+++ b/client/storewebapp/src/components/EditProductForm.js
@@ -1,0 +1,101 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+const API_URL = 'http://localhost:5042/';
+
+const EditProductForm = ({ product, token, onEdited, onCancel }) => {
+  const [title, setTitle] = useState(product.title);
+  const [description, setDescription] = useState(product.description);
+  const [image, setImage] = useState(null);
+  const [categories, setCategories] = useState([]);
+  const [selectedCategories, setSelectedCategories] = useState(
+    product.categories ? product.categories.map(c => c.id) : []
+  );
+  const fileInput = useRef(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}api/storewebapp/GetCategories`)
+      .then(res => res.json())
+      .then(data => setCategories(data))
+      .catch(() => {});
+  }, []);
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    const formData = new FormData();
+    formData.append('title', title);
+    formData.append('description', description);
+    selectedCategories.forEach(id => formData.append('categoryIds', id));
+    if (image) formData.append('image', image);
+
+    fetch(`${API_URL}api/storewebapp/EditProduct/${product.id}`, {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${token}` },
+      body: formData
+    })
+      .then(res => res.json())
+      .then(data => {
+        onEdited && onEdited(data);
+        onCancel && onCancel();
+      })
+      .catch(() => {});
+  };
+
+  const handleFiles = files => {
+    if (files && files[0]) {
+      setImage(files[0]);
+    }
+  };
+
+  const openDialog = () => {
+    fileInput.current?.click();
+  };
+
+  const toggleCategory = id => {
+    setSelectedCategories(prev =>
+      prev.includes(id) ? prev.filter(c => c !== id) : [...prev, id]
+    );
+  };
+
+  return (
+    <form className="add-form" onSubmit={handleSubmit}>
+      <input
+        type="text"
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+        required
+      />
+      <div className="category-select">
+        {categories.map(cat => (
+          <div
+            key={cat.id}
+            className={`category-item ${
+              selectedCategories.includes(cat.id) ? 'selected' : ''
+            }`}
+            onClick={() => toggleCategory(cat.id)}
+          >
+            {cat.name}
+          </div>
+        ))}
+      </div>
+      <textarea
+        value={description}
+        onChange={e => setDescription(e.target.value)}
+        required
+      />
+      <div className="drop-zone" onClick={openDialog}>
+        {image ? image.name : 'Przeciągnij obraz tutaj lub kliknij, aby wybrać'}
+        <input
+          type="file"
+          accept="image/*"
+          ref={fileInput}
+          style={{ display: 'none' }}
+          onChange={e => handleFiles(e.target.files)}
+        />
+      </div>
+      <button type="submit">Zapisz</button>
+      <button type="button" onClick={onCancel}>Anuluj</button>
+    </form>
+  );
+};
+
+export default EditProductForm;

--- a/client/storewebapp/src/components/ProductCard.test.js
+++ b/client/storewebapp/src/components/ProductCard.test.js
@@ -26,3 +26,23 @@ test('shows delete button for admin', async () => {
   expect(btns.length).toBeGreaterThan(0);
 });
 
+test('shows edit button only for admin', async () => {
+  const product = { id: 1, title: 'Test', description: 'Desc' };
+  await act(async () => {
+    render(
+      <ProductCard product={product} apiUrl="/" onDelete={() => {}} isAdmin token="x" />
+    );
+  });
+  expect(screen.getByRole('button', { name: /Edytuj/i })).toBeInTheDocument();
+});
+
+test('hides edit button for normal user', async () => {
+  const product = { id: 1, title: 'Test', description: 'Desc' };
+  await act(async () => {
+    render(
+      <ProductCard product={product} apiUrl="/" onDelete={() => {}} isAdmin={false} token={null} />
+    );
+  });
+  expect(screen.queryByRole('button', { name: /Edytuj/i })).toBeNull();
+});
+

--- a/server/models/EditProductDto.cs
+++ b/server/models/EditProductDto.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace StoreWebApp.Models
+{
+    public class EditProductDto
+    {
+        [Required]
+        public string Title { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public List<long>? CategoryIds { get; set; }
+        public IFormFile? Image { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add admin-only edit endpoint and DTO in the backend
- create EditProductForm component
- show edit button for admins in ProductCard and render form
- style edit button in React app
- cover edit button visibility with tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a9a51ead88326a6e1fbf4069730b8